### PR TITLE
VTD fusions

### DIFF
--- a/elbridge/__init__.py
+++ b/elbridge/__init__.py
@@ -1,5 +1,4 @@
-# from elbridge.plan import Plan
-# from elbridge.graph import Graph
+from elbridge.graph import Graph
 from elbridge.bitmap import Bitmap
 
-__all__ = ['Bitmap', ]
+__all__ = ['Bitmap', 'Graph']

--- a/elbridge/fusions.py
+++ b/elbridge/fusions.py
@@ -16,7 +16,7 @@ def fuse_islands(gdf: GeoDataFrame, adj: W) -> Dict[int, int]:
     :param adj: the VTDs' adjacency matrix.
     """
     closest = {}
-    if len(adj.islands) > 0:
+    if adj.islands:
         # Find distances between island centroids and all VTD centroids.
         distances = np.zeros((len(adj.islands), len(gdf)))
         centroids = [gdf.iloc[idx].geometry.centroid.coords[0]
@@ -33,7 +33,7 @@ def fuse_islands(gdf: GeoDataFrame, adj: W) -> Dict[int, int]:
             closest_idx = 0
             for vtd_idx, vtd_dist in enumerate(list(distances[island_idx])):
                 if (vtd_dist > 0 and vtd_dist < closest_dist and
-                   vtd_idx not in adj.islands):
+                        vtd_idx not in adj.islands):
                     closest_dist = vtd_dist
                     closest_idx = vtd_idx
             closest[island] = closest_idx


### PR DESCRIPTION
We'd like to be able to reproducibly generate and apply _fusions_—constraints that force VTDs to always be allocated together. There are two current cases where this is useful:
- The allocation of island VTDs, which otherwise would be inaccessible from the mainland and thus inaccessible in the VTD graph
- The allocation of VTDs that are within other VTDs, which seems to happen a lot in Wisconsin for some reason

Some fusion functions were previously implemented in `elbridge.fusions`. This PR adds `elbridge.graph.FusionGraph`, which generates a _fusion graph_ from a list of callable fusions and provides a `fuse()` method to apply fusions to a list of VTDs.